### PR TITLE
Fix bug Eclipse-543528

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+build/
+buildSrc/build/
+
+.gradle/
+.build
+.buildSrc
+
+.hg
+.hgtags
+.hgignore
+
+

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkApplication.java
@@ -53,8 +53,8 @@ import java.lang.annotation.Native;
 
 final class GtkApplication extends Application implements
                                     InvokeLaterDispatcher.InvokeLaterSubmitter {
-    private static final String SWT_INTERNAL_CLASS =
-            "org.eclipse.swt.internal.gtk.OS";
+    private static final String SWT_INTERNAL_CLASS_OS = "org.eclipse.swt.internal.gtk.OS";
+    private static final String SWT_INTERNAL_CLASS_GTK = "org.eclipse.swt.internal.gtk.GTK";
     private static final int forcedGtkVersion;
 
 
@@ -63,11 +63,19 @@ final class GtkApplication extends Application implements
         Class<?> OS = AccessController.
                 doPrivileged((PrivilegedAction<Class<?>>) () -> {
                     try {
-                        return Class.forName(SWT_INTERNAL_CLASS, true,
+                        return Class.forName(SWT_INTERNAL_CLASS_GTK, true,
                                 ClassLoader.getSystemClassLoader());
                     } catch (Exception e) {}
                     try {
-                        return Class.forName(SWT_INTERNAL_CLASS, true,
+                        return Class.forName(SWT_INTERNAL_CLASS_GTK, true,
+                                Thread.currentThread().getContextClassLoader());
+                    } catch (Exception e) {}
+                    try {
+                        return Class.forName(SWT_INTERNAL_CLASS_OS, true,
+                                ClassLoader.getSystemClassLoader());
+                    } catch (Exception e) {}
+                    try {
+                        return Class.forName(SWT_INTERNAL_CLASS_OS, true,
                                 Thread.currentThread().getContextClassLoader());
                     } catch (Exception e) {}
                     return null;
@@ -251,8 +259,23 @@ final class GtkApplication extends Application implements
 
         final boolean disableGrab = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("sun.awt.disablegrab") ||
                Boolean.getBoolean("glass.disableGrab"));
+        
+	int windowScale = getWindowScale();
 
-        _init(eventProc, disableGrab);
+        _init(eventProc, disableGrab, windowScale);
+    }
+
+    private int getWindowScale() {
+        String type = AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty("com.sun.javafx.application.type", ""));
+    	if ("FXCanvas".equals(type)) {
+            PlatformLogger logger = Logging.getJavaFXLogger();
+            final int scale = AccessController.doPrivileged((PrivilegedAction<Integer>) () -> Integer.getInteger("org.eclipse.swt.internal.deviceZoom", 100));
+            logger.warning("scale=" + scale);
+            System.out.println("====== SCALE " + scale);
+            return scale / 100;
+    	}
+        System.out.println("====== SCALE FAILURE ===== ");
+    	return 1;
     }
 
     @Override
@@ -296,7 +319,7 @@ final class GtkApplication extends Application implements
 
     private native void _terminateLoop();
 
-    private native void _init(long eventProc, boolean disableGrab);
+    private native void _init(long eventProc, boolean disableGrab, int windowScale);
 
     private native void _runLoop(Runnable launchable, boolean noErrorTrap);
 

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkApplication.java
@@ -259,23 +259,20 @@ final class GtkApplication extends Application implements
 
         final boolean disableGrab = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("sun.awt.disablegrab") ||
                Boolean.getBoolean("glass.disableGrab"));
-        
-	int windowScale = getWindowScale();
+
+        int windowScale = getWindowScale();
 
         _init(eventProc, disableGrab, windowScale);
     }
 
     private int getWindowScale() {
         String type = AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty("com.sun.javafx.application.type", ""));
-    	if ("FXCanvas".equals(type)) {
+        if ("FXCanvas".equals(type)) {
             PlatformLogger logger = Logging.getJavaFXLogger();
             final int scale = AccessController.doPrivileged((PrivilegedAction<Integer>) () -> Integer.getInteger("org.eclipse.swt.internal.deviceZoom", 100));
-            logger.warning("scale=" + scale);
-            System.out.println("====== SCALE " + scale);
             return scale / 100;
-    	}
-        System.out.println("====== SCALE FAILURE ===== ");
-    	return 1;
+        }
+        return 1;
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
@@ -150,7 +150,7 @@ JNIEXPORT jint JNICALL Java_com_sun_glass_ui_gtk_GtkApplication__1queryLibrary
  * Signature: ()V
  */
 JNIEXPORT void JNICALL Java_com_sun_glass_ui_gtk_GtkApplication__1init
-  (JNIEnv * env, jobject obj, jlong handler, jboolean _disableGrab)
+  (JNIEnv * env, jobject obj, jlong handler, jboolean _disableGrab, jint windowScale)
 {
     (void)obj;
 
@@ -158,7 +158,7 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_gtk_GtkApplication__1init
     process_events_prev = (GdkEventFunc) handler;
     disableGrab = (gboolean) _disableGrab;
 
-    glass_gdk_x11_display_set_window_scale(gdk_display_get_default(), 1);
+    glass_gdk_x11_display_set_window_scale(gdk_display_get_default(), windowScale);
     gdk_event_handler_set(process_events, NULL, NULL);
 
     GdkScreen *default_gdk_screen = gdk_screen_get_default();


### PR DESCRIPTION
**Creating an FXCanvas resets HiDPI scaling on GTK3**
Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=543528

**Analysis:**
Initialization of FXCanvas calls `glass_gdk_x11_display_set_window_scale` with the hardcoded scale of 1.
When HiDPI scaling is applied, this causes scaling reset.

**Fix**
The actual scaling for FXCanvas is now fetched from the variable `org.eclipse.swt.internal.deviceZoom` (set by SWT) and passed to  `glass_gdk_x11_display_set_window_scale` using a new param in native method `_init`.

Another small fix: take into account that starting with Eclipse 4.10 methods from `org.eclipse.swt.internal.gtk.OS` were moved to `org.eclipse.swt.internal.gtk.GTK` in Eclipse 4.10.


