### PR TITLE
8264990: WebEngine crashes with segfault when not loaded through system classloader

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/java/JavaEnv.cpp
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/java/JavaEnv.cpp
@@ -42,6 +42,8 @@ bool CheckAndClearException(JNIEnv* env)
 
 namespace WebCore {
 
+JGClass comSunWebkitFileSystem;
+
 jclass PG_GetGraphicsManagerClass(JNIEnv* env)
 {
     static JGClass graphicsManagerCls(
@@ -285,6 +287,21 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*)
     _CrtSetDbgFlag( tmpFlag );
 #endif
     jvm = vm;
+
+    JNIEnv* env = WebCore_GetJavaEnv();
+
+    // Class com.sun.webkit.FileSystem is accessed from a newly created native
+    // thread from FileSystemJava. The class is resolved at initialization time
+    // as in the JNI_OnLoad callback the classloader used to load the native
+    // library is also used to load the target class, which is by construction
+    // the right one
+    static jclass fileSystemClass = env->FindClass("com/sun/webkit/FileSystem");
+
+    ASSERT(fileSystemClass);
+
+    static JGClass fileSystemRef(fileSystemClass);
+    WebCore::comSunWebkitFileSystem = fileSystemRef;
+
     return JNI_VERSION_1_2;
 }
 

--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/java/JavaEnv.h
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/java/JavaEnv.h
@@ -98,6 +98,7 @@ struct EntryJavaLogger
     }
 };
 
+extern JGClass comSunWebkitFileSystem;
 
 } // namespace WebCore
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/java/FileSystemJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/java/FileSystemJava.cpp
@@ -35,25 +35,18 @@ namespace WebCore {
 
 namespace FileSystem {
 
-static jclass GetFileSystemClass(JNIEnv* env)
-{
-    static JGClass clazz(env->FindClass("com/sun/webkit/FileSystem"));
-    ASSERT(clazz);
-    return clazz;
-}
-
 bool fileExists(const String& path)
 {
     JNIEnv* env = WebCore_GetJavaEnv();
 
     static jmethodID mid = env->GetStaticMethodID(
-            GetFileSystemClass(env),
+            comSunWebkitFileSystem,
             "fwkFileExists",
             "(Ljava/lang/String;)Z");
     ASSERT(mid);
 
     jboolean result = env->CallStaticBooleanMethod(
-            GetFileSystemClass(env),
+            comSunWebkitFileSystem,
             mid,
             (jstring)path.toJavaString(env));
     CheckAndClearException(env);
@@ -78,13 +71,13 @@ bool getFileSize(const String& path, long long& result)
     JNIEnv* env = WebCore_GetJavaEnv();
 
     static jmethodID mid = env->GetStaticMethodID(
-            GetFileSystemClass(env),
+            comSunWebkitFileSystem,
             "fwkGetFileSize",
             "(Ljava/lang/String;)J");
     ASSERT(mid);
 
     jlong size = env->CallStaticLongMethod(
-            GetFileSystemClass(env),
+            comSunWebkitFileSystem,
             mid,
             (jstring) path.toJavaString(env));
     CheckAndClearException(env);
@@ -130,13 +123,13 @@ String pathByAppendingComponent(const String& path, const String& component)
     JNIEnv* env = WebCore_GetJavaEnv();
 
     static jmethodID mid = env->GetStaticMethodID(
-            GetFileSystemClass(env),
+            comSunWebkitFileSystem,
             "fwkPathByAppendingComponent",
             "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;");
     ASSERT(mid);
 
     JLString result = static_cast<jstring>(env->CallStaticObjectMethod(
-            GetFileSystemClass(env),
+            comSunWebkitFileSystem,
             mid,
             (jstring)path.toJavaString(env),
             (jstring)component.toJavaString(env)));
@@ -150,13 +143,13 @@ bool makeAllDirectories(const String& path)
     JNIEnv* env = WebCore_GetJavaEnv();
 
     static jmethodID mid = env->GetStaticMethodID(
-            GetFileSystemClass(env),
+            comSunWebkitFileSystem,
             "fwkMakeAllDirectories",
             "(Ljava/lang/String;)Z");
     ASSERT(mid);
 
     jboolean result = env->CallStaticBooleanMethod(
-            GetFileSystemClass(env),
+            comSunWebkitFileSystem,
             mid,
             (jstring)path.toJavaString(env));
     CheckAndClearException(env);
@@ -181,7 +174,7 @@ std::optional<FileMetadata> fileMetadata(const String& path)
     JNIEnv* env = WebCore_GetJavaEnv();
 
     static jmethodID mid = env->GetStaticMethodID(
-            GetFileSystemClass(env),
+            comSunWebkitFileSystem,
             "fwkGetFileMetadata",
             "(Ljava/lang/String;[J)Z");
     ASSERT(mid);
@@ -189,7 +182,7 @@ std::optional<FileMetadata> fileMetadata(const String& path)
     JLocalRef<jlongArray> lArray(env->NewLongArray(3));
 
     jboolean result = env->CallStaticBooleanMethod(
-            GetFileSystemClass(env),
+            comSunWebkitFileSystem,
             mid,
             (jstring)path.toJavaString(env), (jlongArray)lArray);
     CheckAndClearException(env);
@@ -260,13 +253,13 @@ String pathGetFileName(const String& path)
     JNIEnv* env = WebCore_GetJavaEnv();
 
     static jmethodID mid = env->GetStaticMethodID(
-            GetFileSystemClass(env),
+            /comSunWebkitFileSystem,
             "fwkPathGetFileName",
             "(Ljava/lang/String;)Ljava/lang/String;");
     ASSERT(mid);
 
     JLString result = static_cast<jstring>(env->CallStaticObjectMethod(
-            GetFileSystemClass(env),
+            comSunWebkitFileSystem,
             mid,
             (jstring) path.toJavaString(env)));
     CheckAndClearException(env);


### PR DESCRIPTION
Current issue is related to javaFX bug https://bugs.openjdk.java.net/browse/JDK-8264990
There is a fix https://github.com/openjdk/jfx11u/commit/346cf7d04a60f5d8c02e20d9031c87fbe356280c for openJFX 17. it was backported to v.11.0.12. 

There are two ways to fix this issue: migrate DSG to OpenJFX 17 [LTS] or backport that fix.
We will proceed with backport first. 

@mastanarao @ybova 